### PR TITLE
Update serializers.py

### DIFF
--- a/task/serializers.py
+++ b/task/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from .models import Task
 
-class TaskSerializer(serializers.HyperlinkedModelSerializer):
+class TaskSerializer(serializers.ModelSerializer):
     class Meta:
         model = Task
-        fields = ('id', 'description', 'status')
+        fields = '__all__'


### PR DESCRIPTION
To fix this:
"Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed. Add an explicit fields = 'all' to the TaskSerializer serializer."